### PR TITLE
refactor: remove unused English dialects and tones from style defaults

### DIFF
--- a/src/api/style/style.api.defaults.ts
+++ b/src/api/style/style.api.defaults.ts
@@ -1,18 +1,14 @@
 export const STYLE_DEFAULTS = {
   dialects: {
     americanEnglish: 'american_english',
-    australianEnglish: 'australian_english',
     britishOxford: 'british_oxford',
     canadianEnglish: 'canadian_english',
-    indianEnglish: 'indian_english',
   },
   tones: {
     academic: 'academic',
     business: 'business',
-    casual: 'casual',
     conversational: 'conversational',
     formal: 'formal',
-    genZ: 'gen-z',
     informal: 'informal',
     technical: 'technical',
   },


### PR DESCRIPTION
- Eliminated 'australianEnglish', 'indianEnglish', 'casual', and 'genZ' from the STYLE_DEFAULTS object in style.api.defaults.ts to streamline the configuration and improve clarity.