### PR TITLE
Adding robust HTML content support: filename preservation, MIME inference, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install @markupai/toolkit
 
 ### Style Analysis
 
-The toolkit supports string content, File objects, and Buffer objects for style analysis with automatic MIME type detection for binary files:
+The toolkit supports string content, File objects, and Buffer objects for style analysis with automatic MIME type detection for binary files. It also supports HTML content strings and files:
 
 ```typescript
 import {
@@ -35,6 +35,16 @@ const stringRequest = {
   style_guide: 'ap',
   dialect: 'american_english',
   tone: 'formal',
+};
+
+// Using HTML string content (auto-detected as text/html)
+const htmlStringRequest = {
+  content: '<!doctype html><html><body><p>Hello</p></body></html>',
+  style_guide: 'ap',
+  dialect: 'american_english',
+  tone: 'formal',
+  // Optional: provide a filename to enforce MIME type
+  documentName: 'page.html',
 };
 
 // Using File object (browser environments)
@@ -65,6 +75,7 @@ const bufferRequest = {
 const result = await styleCheck(stringRequest, config);
 const fileResult = await styleCheck(fileRequest, config);
 const pdfResult = await styleCheck(bufferRequest, config); // Works with PDFs!
+const htmlResult = await styleCheck(htmlStringRequest, config); // Works with HTML!
 
 // Get style suggestions
 const suggestionResult = await styleSuggestions(stringRequest, config);

--- a/src/api/style/style.api.types.ts
+++ b/src/api/style/style.api.types.ts
@@ -34,6 +34,8 @@ export interface FileDescriptor {
 export interface BufferDescriptor {
   buffer: Buffer;
   mimeType?: string;
+  /** Optional original filename hint for MIME and extension preservation */
+  filename?: string;
 }
 
 /**
@@ -152,6 +154,8 @@ export interface StyleAnalysisReq {
   tone?: string;
   documentName?: string; // Optional document name for the file upload
   webhook_url?: string; // Optional webhook URL for async processing
+  /** Optional alias for documentName; used by some callers */
+  filename?: string;
 }
 
 export interface StyleGuide {


### PR DESCRIPTION
This PR adds HTML support to the style analysis workflow without impacting existing TXT/PDF/Markdown flows or batch/parallel processing.